### PR TITLE
Aggiunto encoding Base64 alla cronologia delle ricerche su firebase

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -7,6 +7,7 @@
         <option name="testRunner" value="GRADLE" />
         <option name="distributionType" value="DEFAULT_WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
+        <option name="gradleJvm" value="Embedded JDK" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -8,7 +8,7 @@
       </map>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="Android Studio default JDK" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="11" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/app/src/main/java/com/cip/cipstudio/dataSource/repository/FirebaseRepository.kt
+++ b/app/src/main/java/com/cip/cipstudio/dataSource/repository/FirebaseRepository.kt
@@ -1,12 +1,11 @@
 package com.cip.cipstudio.dataSource.repository
 
-import android.util.Log
 import com.cip.cipstudio.model.User
 import com.google.android.gms.tasks.Task
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.database.DataSnapshot
-import com.google.firebase.database.DatabaseReference
 import com.google.firebase.database.FirebaseDatabase
+import android.util.Base64
 
 object FirebaseRepository {
     private var db : FirebaseDatabase? = null
@@ -60,12 +59,14 @@ object FirebaseRepository {
             .get()
     }
 
-    fun addQueryToRecentlySearch(gameIdToAdd : String, gameIdToDelete : String? = null) : Task<Void> {
+    fun addQueryToRecentlySearch(queryToAdd : String, queryToDelete : String? = null) : Task<Void> {
         val data : Map<String, Any> = hashMapOf("dateTime" to System.currentTimeMillis())
         val ref = db!!.getReference("users/$userId/recentlySearch")
-        val task = ref.child(gameIdToAdd).setValue(data)
-        if(gameIdToDelete != null){
-            ref.child(gameIdToDelete).removeValue()
+        val encodedQueryToAdd = Base64.encodeToString(queryToAdd.toByteArray(), Base64.NO_WRAP)
+        val task = ref.child(encodedQueryToAdd).setValue(data)
+        if(queryToDelete != null) {
+            val encodedQueryToDelete = Base64.encodeToString(queryToDelete.toByteArray(), Base64.NO_WRAP)
+            ref.child(encodedQueryToDelete).removeValue()
         }
         return task
     }
@@ -75,7 +76,8 @@ object FirebaseRepository {
     }
 
     fun deleteQueryFromRecentlySearch(query : String) : Task<Void> {
-        return db!!.getReference("users/${User.uid}/recentlySearch/$query").removeValue()
+        val encodedQuery = Base64.encodeToString(query.toByteArray(), Base64.NO_WRAP)
+        return db!!.getReference("users/${User.uid}/recentlySearch/$encodedQuery").removeValue()
     }
 
     fun getRecentlySearchesQueries() : Task<DataSnapshot>{

--- a/app/src/main/java/com/cip/cipstudio/model/User.kt
+++ b/app/src/main/java/com/cip/cipstudio/model/User.kt
@@ -27,6 +27,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import android.util.Base64
 
 object User {
     private val TAG = User::class.java.simpleName
@@ -131,7 +132,14 @@ object User {
                 val queries = (it.value as Map<*, *>).map { el ->
                     val a = el.value as Map<*,*>
                     val query = el.key as String
-                    RecentSearchesHistoryEntry(query, uid, a["dateTime"] as Long)
+
+                    try {
+                        val decodedQuery = String(Base64.decode(query, Base64.NO_WRAP))
+                        RecentSearchesHistoryEntry(decodedQuery, uid, a["dateTime"] as Long)
+                    }
+                    catch (iae : IllegalArgumentException) {
+                        RecentSearchesHistoryEntry(query, uid, a["dateTime"] as Long)
+                    }
                 }
 
                 GlobalScope.launch(Dispatchers.IO) {

--- a/build.gradle
+++ b/build.gradle
@@ -6,8 +6,8 @@ buildscript {
 }
 
 plugins {
-    id 'com.android.application' version '7.3.1' apply false
-    id 'com.android.library' version '7.3.1' apply false
+    id 'com.android.application' version '7.4.1' apply false
+    id 'com.android.library' version '7.4.1' apply false
     id 'org.jetbrains.kotlin.android' version '1.7.10' apply false
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Mon Oct 10 18:00:59 CEST 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Allo stato attuale, l'applicazione crasha se si effettuano ricerche con query contenenti alcuni caratteri, come il punto.
L'esempio più banale può essere per esempio cercare "chess.com".

Questo succede perchè la cronologia delle ricerche è in parte salvata sul database remoto di Firebase, e i paths di Firebase non possono contenere i seguenti caratteri: 

`'.', '#', '$', '[', o ']'`

quindi il salvataggio della query fallisce.

Siccome le stringhe di ricerca possono essere di qualsiasi tipo e esistono appunto giochi contenenti questi caratteri nei loro nomi, l'idea dietro la PR per fixare l'issue è effettuare l'encoding delle query prima di salvarle su Firebase, e il decoding dopo averle recuperate da Firebase.

L'encoding dei singoli caratteri potrebbe causare problemi in casi particolari durante il decoding, quindi viene effettuato l'encoding Base64 sull'intera stringa sfruttando una libreria di android.util, di modo da essere certi di riottenere la stringa originale dopo aver effettuato il decoding.

Nota: durante il sync dal database remoto in cui è effettuato il decoding, esso è messo in un try catch per evitare il crash dell'applicazione dovuto a precedenti query salvate su firebase senza encoding, su cui il decoding può fallire.
Questo risolve il crash, ma alcune stringhe precedenti a questa modifica possono comunque essere decodificate (perchè coerenti con la codifica Base64) portando all'aggiunta di strane entry nella cronologia, che è possibile rimuovere singolarmente.

Idealmente parlando, bonificando le entry della cronologia per tutti gli utenti (al momento pochi) su firebase, che andrebbero dunque perse, sarebbe possibile eliminare il blocco try catch e il suo impatto sulle prestazioni, piccolo o grande che sia, dato che da quel momento in poi ogni stringa salvata sarebbe prima codificata.