### PR TITLE
Aggiunta Pagination a Favourite Fragment

### DIFF
--- a/app/src/main/java/com/cip/cipstudio/dataSource/repository/IGDBRepository/IGDBRepository.kt
+++ b/app/src/main/java/com/cip/cipstudio/dataSource/repository/IGDBRepository/IGDBRepository.kt
@@ -20,7 +20,7 @@ interface IGDBRepository {
 
     suspend fun getGameDetails(gameId : String, refresh: Boolean = false) : GameDetails
 
-    suspend fun getGamesByIds(gameIds : List<String>, refresh: Boolean = false) : List<GameDetails>
+    suspend fun getGamesByIds(gameIds : List<String>, refresh: Boolean = false, pageIndex: Int = 0, pageSize: Int = 10) : List<GameDetails>
 
     suspend fun getPlatformsInfo(platformIds : List<String>, refresh: Boolean = false) : List<PlatformDetails>
 

--- a/app/src/main/java/com/cip/cipstudio/dataSource/repository/IGDBRepository/IGDBRepositoryRemote.kt
+++ b/app/src/main/java/com/cip/cipstudio/dataSource/repository/IGDBRepository/IGDBRepositoryRemote.kt
@@ -248,13 +248,15 @@ object IGDBRepositoryRemote : IGDBRepository {
         return@withContext Converter.fromJsonArrayToGameDetailsArrayList(json)
     }
 
-    override suspend fun getGamesByIds(gameIds: List<String>, refresh: Boolean): List<GameDetails> = withContext(Dispatchers.IO) {
+    override suspend fun getGamesByIds(gameIds: List<String>, refresh: Boolean, pageIndex: Int, pageSize: Int): List<GameDetails> = withContext(Dispatchers.IO) {
         if (gameIds.isEmpty())
             return@withContext arrayListOf()
         val idListString = buildIdsForRequest(gameIds)
         val apicalypse = APICalypse()
             .fields("name, id, cover.url, genres.name, rating, platforms.name, first_release_date")
             .where("id = $idListString")
+            .limit(pageSize)
+            .offset(pageIndex * pageSize)
         val json = makeRequest ({ IGDBWrapper.jsonGames(apicalypse) }, "getGamesByIds${idListString}", refresh)
         return@withContext Converter.fromJsonArrayToGameDetailsArrayList(json)
     }
@@ -439,7 +441,7 @@ object IGDBRepositoryRemote : IGDBRepository {
     }
 
     private fun buildIdsForRequest(ids : List<Any>) : String {
-        return ids.toString().replace("[", "(").replace("]", ")");
+        return ids.toString().replace("[", "(").replace("]", ")")
     }
 
 }

--- a/app/src/main/java/com/cip/cipstudio/viewmodel/FavouriteViewModel.kt
+++ b/app/src/main/java/com/cip/cipstudio/viewmodel/FavouriteViewModel.kt
@@ -35,20 +35,17 @@ class FavouriteViewModel(val binding : FragmentFavouriteBinding) : ViewModel() {
                    notLoggedInUI: () -> Unit = {}) {
         user.getFavouriteGames().addOnSuccessListener {
             if (it.value != null) {
-                if(((it.value as Map<*, *>).size - 10*offset) > 0) {
-                    (it.value as Map<*, *>).forEach {
-                        favouriteGamesIds.add(it.value.toString())
-                    }
-                    viewModelScope.launch(Dispatchers.Main) {
-                        favouriteGames = withContext(Dispatchers.IO){
-                            IGDBRepositoryRemote.getGamesByIds(favouriteGamesIds, refresh, offset) as ArrayList<GameDetails>
-                        }
-                        isMoreDataAvailable.postValue(favouriteGames.isNotEmpty())
-                        updateUI.invoke(favouriteGames)
-                        isPageLoading.postValue(false)
-                    }
+                (it.value as Map<*, *>).forEach {
+                    favouriteGamesIds.add(it.value.toString())
                 }
-
+                viewModelScope.launch(Dispatchers.Main) {
+                    favouriteGames = withContext(Dispatchers.IO){
+                        IGDBRepositoryRemote.getGamesByIds(favouriteGamesIds, refresh, offset) as ArrayList<GameDetails>
+                    }
+                    isMoreDataAvailable.postValue(favouriteGames.isNotEmpty())
+                    updateUI.invoke(favouriteGames)
+                    isPageLoading.postValue(false)
+                }
             }
             else {
                 noFavouriteUI.invoke()


### PR DESCRIPTION
Al momento l'applicazione è in grado di mostrare solamente 10 preferiti nel Favourite Fragment, anche se più di 10 giochi vengono aggiunti come tali.

Questo succede perchè la chiamata a DB di firebase recupera correttamente l'intero array degli ID salvati come preferiti, ma la successiva chiamata all'API di IGDB, restituisce solamente i primi 10 risultati dati dai primi 10 ID dell'array recuperato da firebase, in quanto una chiamata sprovvista del parametro limit utilizzerà sempre e comunque il suo valore di default (10).

La pull request risolve il problema aggiungendo al fragment l'onScroll Pagination simile a quello già utilizzato nella GameList, e sistemando la chiamata all'API con offset e limit.